### PR TITLE
Make sure the mobile menu is hidden on larger screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -760,3 +760,9 @@ textarea{
   }
 
 }
+
+@media (min-width: 768px) {
+  .mobile_menu {
+    display: none;
+  }
+}


### PR DESCRIPTION
I couldn't reproduce this problem consistently, but this should just prevent the mobile menu from showing on larger screens, right?
